### PR TITLE
ifix for Sonar issue: Disable access to external XML entities

### DIFF
--- a/src/main/java/pl/kubiczak/maven/contentpackage/filters/maven/plugin/XmlFormatter.java
+++ b/src/main/java/pl/kubiczak/maven/contentpackage/filters/maven/plugin/XmlFormatter.java
@@ -23,6 +23,8 @@ import org.w3c.dom.NodeList;
  */
 class XmlFormatter {
 
+  private static final Integer XML_INDENT = 2;
+
   private final Log mavenLog;
 
   public XmlFormatter(Log mavenLog) {
@@ -64,15 +66,14 @@ class XmlFormatter {
   }
 
   private Transformer createTransformer() throws TransformerConfigurationException {
-    Integer indentNumber = 2;
     XmlTransformerFactory xmlTransformerFactory = new XmlTransformerFactory(mavenLog)
-        .addFactoryAttribute("indent-number", indentNumber);
+        .addFactoryAttribute("indent-number", XML_INDENT);
     XmlTransformer xmlTransformer = new XmlTransformer(mavenLog, xmlTransformerFactory)
         .addOutputProperty(OutputKeys.METHOD, "xml")
         .addOutputProperty(OutputKeys.ENCODING, "UTF-8")
         .addOutputProperty(OutputKeys.INDENT, "yes")
-        .addOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
-        .addOutputProperty("{http://xml.apache.org/xalan}indent-amount", "2")
+        .addOutputProperty("{http://xml.apache.org/xslt}indent-amount", XML_INDENT.toString())
+        .addOutputProperty("{http://xml.apache.org/xalan}indent-amount", XML_INDENT.toString())
         // for newline after XML declaration - https://stackoverflow.com/a/18251901
         .addOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
     Transformer transformer = xmlTransformer.create();

--- a/src/main/java/pl/kubiczak/maven/contentpackage/filters/maven/plugin/XmlTransformerFactory.java
+++ b/src/main/java/pl/kubiczak/maven/contentpackage/filters/maven/plugin/XmlTransformerFactory.java
@@ -12,6 +12,8 @@ import org.apache.maven.plugin.logging.Log;
  */
 class XmlTransformerFactory {
 
+  private static final String EXTERNAL_REFERENCES_DENIED = "";
+
   private final Log mavenLog;
 
   private final Map<String, Object> factoryAttributes;
@@ -30,6 +32,8 @@ class XmlTransformerFactory {
       throws TransformerConfigurationException {
     TransformerFactory factory = TransformerFactory.newInstance();
     factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, EXTERNAL_REFERENCES_DENIED);
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, EXTERNAL_REFERENCES_DENIED);
     // factory attributes entry set is ordered (as the implementation is LinkedHashMap)
     mavenLog.debug("Setting attributes: '" + factoryAttributes
         + "' for the factory: '" + factory + "'.");


### PR DESCRIPTION
As suggested by Sonarcloud:

* [java:S2755](https://sonarcloud.io/organizations/wiiitek-github/rules?open=java%3AS2755&rule_key=java%3AS2755)